### PR TITLE
Add matplotlib to python-panda

### DIFF
--- a/python-panda/requirements.txt
+++ b/python-panda/requirements.txt
@@ -8,3 +8,4 @@ sklearn
 xlrd == 1.2.0
 openpyxl >= 3.0.3
 wheel
+matplotlib


### PR DESCRIPTION
Towards https://github.com/oceanprotocol/ocean.py/issues/705

Changes proposed in this PR:

- Add `matplotlib` to `algo_dockers:python-panda` docker image